### PR TITLE
Fixing editable Title for Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Save for later",
-	"version": "1.2",
+	"version": "1.2.1",
 
 	"description": "Save tabs in window to be used later",
 

--- a/popup/main.css
+++ b/popup/main.css
@@ -71,6 +71,7 @@ body {
   text-align: left;
   float: left;
   flex-grow: 1;
+  white-space: pre-wrap;
 }
 
 .iconBtn {

--- a/popup/warehouse.js
+++ b/popup/warehouse.js
@@ -82,6 +82,10 @@ function createList(storeObj) {
           event.preventDefault();
           handleTitleUpdate(obj, saveTitle)
         }
+        if (event.key === ' ') {
+          event.preventDefault();
+          insertTextAtCaret(' ');
+        }
       })
 
       saveTitle.addEventListener('focusout', () => {
@@ -178,7 +182,7 @@ function validateAndUpdateTitle(obj, newTitleText) {
 }
 
 function santizeTitleName(titleText) {
-  const maxTitleLength = 29
+  const maxTitleLength = 40
   if (titleText.length >= maxTitleLength) {
     return titleText.substring(0, maxTitleLength);
   }
@@ -228,6 +232,18 @@ function validateAndOpenSave(obj) {
           openSave(urlArray, false, [])
         })
     });
+}
+
+// Reference: https://stackoverflow.com/a/75505941/4688365
+function insertTextAtCaret(text) {
+  var sel, range;
+  sel = window.getSelection();
+  if (sel && sel.getRangeAt && sel.rangeCount) {
+    range = sel.getRangeAt(0);
+    range.deleteContents();
+    range.insertNode(document.createTextNode(text));
+    range.collapse();
+  }
 }
 
 async function storeIt(tabs) {


### PR DESCRIPTION
Changes in thsi PR:

- Fix editable titles in Firefox:
  - Insert spaces
  - Insert multiple spaces in sequence
  - Insert spaces at the end
- Increase max limit of Title Text, since alignments are now handled in CSS
- Bumping version to 1.2.1 (bugfix version)